### PR TITLE
Field selection as parameter

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -257,7 +257,7 @@ var LocationState = State.extend(function(self, name, opts) {
         results.forEach(function(res) {
             var result = {};        // Used to generate single result object
             self.store_fields.forEach(function(field) {
-                result[field]=res[field];
+                result[field]=self.extract_object(res, field);
             });
             // Ensure that formatted_address is included as it is needed to
             // generate the pages.
@@ -269,6 +269,16 @@ var LocationState = State.extend(function(self, name, opts) {
         return addresses;
     };
 
+    // Takes a field as a string, eg 'foo.bar.baz', and extracts the actual 
+    // object, ie. obj.foo.bar.baz
+    self.extract_object = function(obj, field) {
+        var split = field.split('.');
+        split.forEach(function(value) {
+            obj = obj[value];
+        });
+        return obj;
+    };
+
     // Stores the address data to the contact. Stores the string 'data' in the
     // ContactStore
     self.store_contact_data = function(data) {
@@ -276,7 +286,12 @@ var LocationState = State.extend(function(self, name, opts) {
         if(self.store_fields.indexOf('formatted_address')==-1){
             delete data.formatted_address;
         }
-        self.contact.location = JSON.stringify(data);
+        // Store each parameter
+        _.each(data, function(value, parameter) {
+            self.contact.extra['location:' + parameter.replace(/\./g,':')] = 
+                JSON.stringify(value);
+        });
+
         return self.im.contacts.save(self.contact);
     };
 

--- a/test/test_location.js
+++ b/test/test_location.js
@@ -49,6 +49,14 @@ describe('states.location', function() {
                 return new LocationState(name, tester.data.opts);
             });
 
+            app.states.add('states:test-nested', function(name) {
+                tester.data.opts = {
+                    store_fields:['geometry.bounds.northeast.lng'],
+                    next:'states:end'
+                };
+                return new LocationState(name, tester.data.opts);
+            });
+
             app.states.add('states:end', function(name) {
                 return new EndState(name, {
                     text: 'This is the end state.'
@@ -210,10 +218,8 @@ describe('states.location', function() {
                 })
                 .check(function(api) {
                     var contact = api.contacts.store[0];
-                    assert.equal(contact.location, JSON.stringify({
-                        formatted_address:
-                            "Friend Street, Amesbury, MA 01913, USA"
-                    }));
+                    assert.equal(contact.extra['location:formatted_address'],
+                            '"Friend Street, Amesbury, MA 01913, USA"');
                 })
                 .run();
         });
@@ -227,10 +233,8 @@ describe('states.location', function() {
                 })
                 .check(function(api) {
                     var contact = api.contacts.store[0];
-                    assert.equal(contact.location, JSON.stringify({
-                        formatted_address:
-                            'Friend Street, Boston, MA 02114, USA'
-                    }));
+                    assert.equal(contact.extra['location:formatted_address'],
+                            '"Friend Street, Boston, MA 02114, USA"');
                 })
                 .run();
         });
@@ -244,10 +248,8 @@ describe('states.location', function() {
                 })
                 .check(function(api) {
                     var contact = api.contacts.store[0];
-                    assert.equal(contact.location, JSON.stringify({
-                            formatted_address:
-                                "Friend Street, Cape Town 7925, South Africa"
-                        }));
+                    assert.equal(contact.extra['location:formatted_address'], 
+                        '"Friend Street, Cape Town 7925, South Africa"');
                 })
                 .run();
         });
@@ -264,9 +266,7 @@ describe('states.location', function() {
             })
             .check(function(api) {
                 var contact = api.contacts.store[0];
-                assert.equal(contact.location, JSON.stringify({
-                    "types" : [ "route" ]
-                }));
+                assert.equal(contact.extra['location:types'], '["route"]');
             })
             .run();
         });
@@ -339,6 +339,25 @@ describe('states.location', function() {
             })
             .run();
         });
+
+        it('should understand nested parameters for field options',
+            function() {
+                return tester
+                .setup.user.state({
+                    name:'states:test-nested'
+                })
+                .inputs("Friend Street, South Africa")
+                .check.interaction({
+                    state:'states:end'
+                })
+                .check(function(api) {
+                    var contact = api.contacts.store[0];
+                    assert.equal(contact.extra[
+                        'location:geometry:bounds:northeast:lng'], 
+                        '18.4575469');
+                })
+                .run();
+            });
 
     });
 });


### PR DESCRIPTION
Allow the fields that are selected to be stored to be selected via a parameter. This will allow custom selection of which fields from the Google Maps results should be stored in the contact data.
