### PR TITLE
Add support for key parameter for OSM

### DIFF
--- a/examples/lib/openstreetmap.js
+++ b/examples/lib/openstreetmap.js
@@ -20,7 +20,9 @@ var LocationApp = App.extend(function(self){
             ].join("\n"),
             next: "states:end",
             previous_text: "Prev",
-            map_provider: new OpenStreetMap(),
+            map_provider: new OpenStreetMap({
+                api_key: self.im.config.api_key,
+            }),
         });
     });
 

--- a/examples/test/test_openstreetmap.js
+++ b/examples/test/test_openstreetmap.js
@@ -20,6 +20,7 @@ describe("OpenStreetMap example", function() {
                 "Example Street, Suburb",
                 "Another Street, Suburb",
             ],
+            key: 'testapikey',
         });
 
         locations.push({
@@ -27,11 +28,13 @@ describe("OpenStreetMap example", function() {
             address_list: [
                 "Single Street, Suburb",
             ],
+            key: 'testapikey',
         });
 
         tester
             .setup.config.app({
-                name: 'test_app'
+                name: 'test_app',
+                api_key: 'testapikey',
             })
             .setup(function(api) {
                 locations.forEach(function(location) {

--- a/lib/providers/openstreetmap/fixture.js
+++ b/lib/providers/openstreetmap/fixture.js
@@ -8,6 +8,9 @@ function fixture(opts) {
 
     Returns an HTTP resource fixture for an OpenStreetMap location query.
 
+    :param string opts.key:
+        The API key to use for requests. Required.
+
     :param string opts.query:
         The address that is to be queried. Required.
 
@@ -82,6 +85,12 @@ function fixture(opts) {
         );
     }
 
+    if (typeof opts.key === 'undefined') {
+        throw new FixtureParameterMissingError(
+            "'key' option is required when creating an OpenStreetMap fixture."
+        );
+    }
+
     if (!opts.response_data) {
         opts.response_data = _.map(opts.address_list, function(address) {
                 return {display_name: address};
@@ -93,6 +102,7 @@ function fixture(opts) {
             method: "GET",
             url: opts.request_url,
             params: {
+                key: opts.key,
                 format: "json",
                 q: opts.query,
                 addressdetails: "1",

--- a/lib/providers/openstreetmap/provider.js
+++ b/lib/providers/openstreetmap/provider.js
@@ -16,6 +16,9 @@ var OpenStreetMap = Provider.extend(function (self, opts) {
         The URL of the Open Street Map API. Defaults to
         'http://open.mapquestapi.com/nominatim/v1/search.php'.
 
+    :param string opts.api_key:
+        The key for access to the Open Street Maps API. Defaults to null.
+
     :param function opts.extract_address_label:
         Function that extracts a human-friendly label from an Open Street Map
         API result. See :meth:`OpenStreetMap.extract_address_label` for the
@@ -46,6 +49,7 @@ var OpenStreetMap = Provider.extend(function (self, opts) {
     // Defaults
     opts = _.defaults(opts || {}, {
         api_url: 'http://open.mapquestapi.com/nominatim/v1/search.php',
+        api_key: null,
         extract_address_label: null,
         extract_address_data: null,
         hard_boundary: true,
@@ -57,6 +61,7 @@ var OpenStreetMap = Provider.extend(function (self, opts) {
 
     // Attributes
     self.api_url = opts.api_url;
+    self.api_key = opts.api_key;
     self.hard_boundary = opts.hard_boundary;
     self.address_limit = opts.address_limit;
     self.bounding_box = opts.bounding_box;
@@ -140,6 +145,7 @@ var OpenStreetMap = Provider.extend(function (self, opts) {
 
     self.api_params = function(query_text) {
         return {
+            key: self.api_key,
             format: 'json',
             q: query_text,
             addressdetails: 1,

--- a/test/fixtures/openstreetmap.js
+++ b/test/fixtures/openstreetmap.js
@@ -7,6 +7,7 @@ module.exports = function() {
             "method": "GET",
             "url": "http://open.mapquestapi.com/nominatim/v1/search.php",
             "params": {
+               key: 'testapikey',
                format: "json",
                q: "Foe Street",
                addressdetails: "1",
@@ -111,6 +112,7 @@ module.exports = function() {
             "method": "GET",
             "url": "http://open.mapquestapi.com/nominatim/v1/search.php",
             "params": {
+               key: 'testapikey',
                format: "json",
                q: "no_data",
                addressdetails: "1",
@@ -130,6 +132,7 @@ module.exports = function() {
             "method": "GET",
             "url": "http://open.mapquestapi.com/nominatim/v1/search.php",
             "params": {
+               key: 'testapikey',
                format: "json",
                q: "empty_data",
                addressdetails: "1",
@@ -150,6 +153,7 @@ module.exports = function() {
             "method": "GET",
             "url": "http://example.com/nominatim/v1/search.php",
             "params": {
+               key: 'testapikey',
                format: "json",
                q: "Moon",
                addressdetails: "1",

--- a/test/providers/openstreetmap/test_fixture.js
+++ b/test/providers/openstreetmap/test_fixture.js
@@ -17,12 +17,14 @@ describe('openstreetmap.fixture', function() {
             openstreetmap.fixture({
                 query: "Baker Street",
                 address_list: ["2B", "Not 2B"],
+                key: 'testapikey',
             }),
             {
                request: {
                    method: "GET",
                    url: "http://open.mapquestapi.com/nominatim/v1/search.php",
                    params: {
+                       key: 'testapikey',
                        format: "json",
                        q: "Baker Street",
                        addressdetails: "1",
@@ -51,6 +53,7 @@ describe('openstreetmap.fixture', function() {
             function() {
                 openstreetmap.fixture({
                     address_list: ["2B"],
+                    key: 'testapikey',
                 });
             },
             function(err) {
@@ -65,10 +68,31 @@ describe('openstreetmap.fixture', function() {
         );
     });
 
+    it('should require a key parameter', function() {
+        assert.throws(
+            function() {
+                openstreetmap.fixture({
+                    address_list: ["2B"],
+                    query: "Where am I?",
+                });
+            },
+            function(err) {
+                assert(err instanceof FixtureParameterMissingError,
+                       "Expected an instance of FixtureParameterMissingError");
+                assert.strictEqual(err.message, [
+                    "'key' option is required when creating an",
+                    " OpenStreetMap fixture.",
+                ].join(""));
+                return true;
+            }
+        );
+    });
+
     it('should allow setting the hard boundary', function() {
        var fixture = openstreetmap.fixture({
            query: "Where am I?",
            hard_boundary: false,
+           key: 'testapikey',
        });
        assert.strictEqual(fixture.request.params.bounded, "0");
     });
@@ -77,6 +101,7 @@ describe('openstreetmap.fixture', function() {
        var fixture = openstreetmap.fixture({
            query: "Where am I?",
            address_limit: 5,
+           key: 'testapikey',
        });
        assert.strictEqual(fixture.request.params.limit, "5");
     });
@@ -85,6 +110,7 @@ describe('openstreetmap.fixture', function() {
        var fixture = openstreetmap.fixture({
            query: "Where am I?",
            bounding_box: ["1.0", "2.0", "3.0", "4.0"],
+           key: 'testapikey',
        });
        assert.strictEqual(
            fixture.request.params.viewbox,
@@ -96,6 +122,7 @@ describe('openstreetmap.fixture', function() {
        var fixture = openstreetmap.fixture({
            query: "Where am I?",
            request_url: "http://www.example.com",
+           key: 'testapikey',
        });
        assert.strictEqual(fixture.request.url, "http://www.example.com");
     });
@@ -103,6 +130,7 @@ describe('openstreetmap.fixture', function() {
     it('should default to an empty address list', function() {
        var fixture = openstreetmap.fixture({
            query: "Place with no places",
+           key: 'testapikey',
        });
        assert.deepEqual(fixture.response.data, []);
     });
@@ -114,6 +142,7 @@ describe('openstreetmap.fixture', function() {
             response_data: [
                 {place: 1}, {place: 2},
             ],
+            key: 'testapikey',
         });
         assert.deepEqual(fixture.response.data, [
             {place: 1}, {place: 2},
@@ -124,7 +153,9 @@ describe('openstreetmap.fixture', function() {
         var im, osm;
 
         beforeEach(function() {
-            osm = new openstreetmap.OpenStreetMap();
+            osm = new openstreetmap.OpenStreetMap({
+                api_key: 'testapikey'
+            });
             return test_utils
                 .make_im()
                 .then(function(dummy_im) {
@@ -137,6 +168,7 @@ describe('openstreetmap.fixture', function() {
             var fixture = openstreetmap.fixture({
                 query: "Baker Street",
                 address_list: ["2B", "Not 2B"],
+                key: 'testapikey',
             });
             im.api.http.fixtures.add(fixture);
             return osm

--- a/test/providers/openstreetmap/test_provider.js
+++ b/test/providers/openstreetmap/test_provider.js
@@ -132,6 +132,7 @@ describe('OpenStreetMap', function() {
 
         function assert_params(params, expected) {
             expected = _.defaults(expected, {
+                key: null,
                 format: 'json',
                 q: default_query,
                 addressdetails: 1,
@@ -206,6 +207,15 @@ describe('OpenStreetMap', function() {
                 viewbox: '-20.0,75.0,65.0,-50.0',
             });
         });
+
+        it('should set the api key', function() {
+            var params = api_params({
+                api_key: 'testapikey',
+            });
+            assert_params(params, {
+                key: 'testapikey',
+            });
+        });
     });
 
     describe('.search()', function() {
@@ -220,7 +230,9 @@ describe('OpenStreetMap', function() {
         });
 
         it('should return a promise with a list of AddressResults', function() {
-            var osm = new OpenStreetMap();
+            var osm = new OpenStreetMap({
+                api_key: 'testapikey',
+            });
             osm.init(im);
             return osm.search('Foe Street')
                 .then(function(results) {
@@ -246,6 +258,7 @@ describe('OpenStreetMap', function() {
 
         it('should use the custom api_url if one is given', function() {
             var osm = new OpenStreetMap({
+                api_key: 'testapikey',
                 api_url: 'http://example.com/nominatim/v1/search.php',
             });
             osm.init(im);
@@ -258,7 +271,9 @@ describe('OpenStreetMap', function() {
 
         describe('should return a promise with an empty list if', function() {
             it('the response has no data', function() {
-                var osm = new OpenStreetMap();
+                var osm = new OpenStreetMap({
+                    api_key: 'testapikey',
+                });
                 osm.init(im);
                 return osm.search("no_data")
                     .then(function(results) {
@@ -267,7 +282,9 @@ describe('OpenStreetMap', function() {
             });
 
             it('the response data is empty', function() {
-                var osm = new OpenStreetMap();
+                var osm = new OpenStreetMap({
+                    api_key: 'testapikey',
+                });
                 osm.init(im);
                 return osm.search("empty_data")
                     .then(function(results) {


### PR DESCRIPTION
As of 15 September, API requests to Open Street Maps now require an API key to access. We need to be able to add this key to the request that the location state makes. 
![screen shot 2015-10-29 at 11 22 15 am](https://cloud.githubusercontent.com/assets/8234653/10814548/5a78bb96-7e2f-11e5-8bc7-4a1c511eb6e2.png)
