### PR TITLE
Reject invalid choice number selection.

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -222,10 +222,14 @@ var LocationState = State.extend(function (self, name, opts) {
 
     // User selects location
     self.handlers.refinequestion.number = function(content) {
-        if(isNaN(content)) { return; }
-        // Store the selected address, and advance to next state
+        content = +content;
+        if (!content) { return; }
         var current_page_no = self.metadata.current_page;
-        var address = self.metadata.pages[current_page_no].options[content-1];
+        var current_page = self.metadata.pages[current_page_no];
+        var current_options = current_page.options;
+        if (content < 1 || content > current_options.length) { return; }
+        // Store the selected address, and advance to next state
+        var address = current_page.options[content-1];
         return self.store_contact_data(address)
             .then(function() {
                 return self.set_next_state(self.next, address);

--- a/test/test_location.js
+++ b/test/test_location.js
@@ -211,6 +211,39 @@ describe('states.location', function() {
                 .run();
         });
 
+        it('should stay on the same page if too big a number is entered',
+        function() {
+            return tester
+                .inputs("Friend Street", '3')
+                .check.interaction({
+                    state:'states:test',
+                    reply:[
+                        'Please select your location from the following:',
+                        '1. Friend Street, Amesbury, MA 01913, USA',
+                        '2. Friend Street, Adams, MA 01220, USA',
+                        'n. Next',
+                        'p. Previous'
+                    ].join('\n')
+                })
+                .run();
+        });
+
+        it('should stay on the same page if too small a number is entered',
+        function() {
+            return tester
+                .inputs("Friend Street", '0')
+                .check.interaction({
+                    state:'states:test',
+                    reply:[
+                        'Please select your location from the following:',
+                        '1. Friend Street, Amesbury, MA 01913, USA',
+                        '2. Friend Street, Adams, MA 01220, USA',
+                        'n. Next',
+                        'p. Previous'
+                    ].join('\n')
+                })
+                .run();
+        });
 
         describe('when a location is selected from the list', function() {
             it('should go to the next state', function() {


### PR DESCRIPTION
Currently selecting a number less than or equal to 0 or greater than the largest choice accepts the input and then fails trying to store a null address.
